### PR TITLE
Re-enable composer scipts

### DIFF
--- a/Composer-Recipe.rb
+++ b/Composer-Recipe.rb
@@ -2,7 +2,7 @@ namespace :composer do
 
   _cset(:composer_bin) { false }
   _cset(:php_bin) { "php" }
-  _cset(:composer_options) { "--no-scripts --verbose --prefer-dist --no-dev" }
+  _cset(:composer_options) { "--verbose --prefer-dist --no-dev" }
 
   desc "Ensure the latest Composer version is available - Gets composer and installs it or just update"
   task :get, :roles => :app, :except => { :no_release => true } do


### PR DESCRIPTION
Why should composer scripts(or callbacks) should be disabled? I don't
see any good reasons to it.
